### PR TITLE
build: use official packages for types and loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,13 +20,13 @@
         "not ie < 11"
     ],
     "dependencies": {
+        "@googlemaps/js-api-loader": "^1.11.1",
         "@paperbits/common": "0.1.378",
         "@paperbits/styles": "0.1.378",
         "await-parallel-limit": "^2.1.0",
         "basiclightbox": "^5.0.3",
         "cropperjs": "^1.5.9",
         "file-saver": "^2.0.2",
-        "google-maps": "^4.3.2",
         "html-minifier-terser": "^5.1.1",
         "html2plaintext": "^2.1.2",
         "knockout": "^3.5.1",
@@ -39,7 +39,7 @@
         "xhr2": "^0.2.0"
     },
     "devDependencies": {
-        "@types/google-maps": "^3.2.2",
+        "@types/google.maps": "^3.44.1",
         "@types/knockout.mapping": "^2.0.35",
         "@types/knockout.validation": "0.0.37",
         "@types/lodash": "^4.14.161",

--- a/src/map/ko/bindingHandlers.googlemap.ts
+++ b/src/map/ko/bindingHandlers.googlemap.ts
@@ -1,5 +1,5 @@
 ﻿import * as ko from "knockout";
-import { Loader, LoaderOptions } from "google-maps";
+import { Loader, LoaderOptions } from "@googlemaps/js-api-loader";
 import { MapRuntimeConfig } from "./runtime/mapRuntimeConfig";
 
 
@@ -16,9 +16,9 @@ export class GooglmapsBindingHandler {
     }
 
     private async attach(element: Element, configuration: any): Promise<void> {
-        const options: LoaderOptions = {/* todo */ };
-        const loader = new Loader(configuration.apiKey(), options);
-        const google = await loader.load();
+        const options: Partial<LoaderOptions> = {/* todo */ };
+        const loader = new Loader({apiKey: configuration.apiKey(), ...options});
+        await loader.load();
 
         const geocoder = new google.maps.Geocoder();
         const mapOptions: google.maps.MapOptions = {};


### PR DESCRIPTION
This is the official package used for dynamically loading the Google Maps JS API. While it is still open source and community supported, it is officially maintained by my team(Google Maps Platform Developer Relations).

The benefits over the other package are:

- Up to date options including some beta features
- Larger user base including companies such as Lyft
- Maintained by Google Developer Relations
- Better error handling with singleton pattern