### PR TITLE
Use string key instead of type as handler description for widgets

### DIFF
--- a/src/button/button.design.module.ts
+++ b/src/button/button.design.module.ts
@@ -10,6 +10,8 @@ import { ButtonEditor } from "./ko/buttonEditor";
 import { ButtonViewModelBinder } from "./ko/buttonViewModelBinder";
 
 export class ButtonDesignModule implements IInjectorModule {
+    public static buttonHandlerKey = "buttonHandler";
+
     public register(injector: IInjector): void {
         injector.bind("button", Button);
         injector.bind("buttonEditor", ButtonEditor);
@@ -41,7 +43,7 @@ export class ButtonDesignModule implements IInjectorModule {
             iconClass: "widget-icon widget-icon-button",
             componentBinder: KnockoutComponentBinder,
             componentDefinition: ButtonEditor,
-            handlerComponent: ButtonHandlers
+            handlerComponent: ButtonDesignModule.buttonHandlerKey,
         });
     }
 }

--- a/src/menu/ko/menuViewModelBinder.ts
+++ b/src/menu/ko/menuViewModelBinder.ts
@@ -6,7 +6,6 @@ import { HyperlinkModel } from "@paperbits/common/permalinks";
 import { StyleCompiler } from "@paperbits/common/styles";
 import { ViewModelBinder } from "@paperbits/common/widgets";
 import { MenuContract, MenuModelBinder } from "..";
-import { MenuHandlers } from "../menuHandlers";
 import { MenuModel } from "../menuModel";
 import { MenuItemViewModel } from "./menuItemViewModel";
 import { MenuViewModel } from "./menuViewModel";
@@ -72,7 +71,7 @@ export class MenuViewModelBinder implements ViewModelBinder<MenuModel, MenuViewM
             model: model,
             flow: ComponentFlow.Inline, // Commented out due do discovered backward compatibility issues.
             draggable: true,
-            handler: MenuHandlers,
+            handler: "menuHandler",
             editor: "menu-editor",
             applyChanges: async (updates: MenuModel) => {
                 const contract: MenuContract = {

--- a/src/section/ko/sectionViewModelBinder.ts
+++ b/src/section/ko/sectionViewModelBinder.ts
@@ -49,7 +49,7 @@ export class SectionViewModelBinder implements ViewModelBinder<SectionModel, Sec
             model: model,
             draggable: true,
             editor: "layout-section-editor",
-            handler: SectionHandlers,
+            handler: "sectionHandler",
             applyChanges: async () => {
                 await this.modelToViewModel(model, viewModel, bindingContext);
                 this.eventManager.dispatchEvent(Events.ContentUpdate);


### PR DESCRIPTION
Together with [PR in common library](https://github.com/paperbits/paperbits-common/pull/12) it will allow to easily override handlers for widgets.