### PR TITLE
Fix style reference for localized home page

### DIFF
--- a/src/publishing/pagePublisher.ts
+++ b/src/publishing/pagePublisher.ts
@@ -97,9 +97,9 @@ export class PagePublisher implements IPublisher {
                 template: template,
                 styleReferences: [
                     `/styles/styles.css`, // global style reference
-                    pagePermalink === "/" // local style reference
-                        ? `/styles.css`   // home page style reference
-                        : `${pagePermalink}/styles.css`
+                    page.permalink === "/"
+                        ? `${pagePermalink}styles.css`  // home page style reference
+                        : `${pagePermalink}/styles.css` // local style reference
                 ],
                 author: siteAuthor,
                 socialShareData: page.socialShareData,


### PR DESCRIPTION
Fixes style references for home page from
```
    <link href="/en-us//styles.css" rel="stylesheet" type="text/css" />
```
to
```
    <link href="/en-us/styles.css" rel="stylesheet" type="text/css" />
```