### PR TITLE
Fixed dropdown issue when options are initialized later

### DIFF
--- a/src/dropdown/ko/dropdown.ts
+++ b/src/dropdown/ko/dropdown.ts
@@ -48,10 +48,18 @@ export class Dropdown {
         this.displayedOptions = ko.observable<SelectOption[]>([]);
         this.optionsCaption = ko.observable<string>();
         this.heading = ko.observable<string>();
+
+        this.options.subscribe(this.initialize.bind(this));
     };
 
     @OnMounted()
     public initialize(): void {
+        if(!this.options() || this.options().length === 0) {
+            return;
+        }
+
+        this.displayedOptions([]);
+
         if (this.isOptionsArrayOfStrings()) {
             const options = this.options().map(opiton => { return { "value": opiton, "text": opiton } });
             this.displayedOptions(this.displayedOptions().concat(options));


### PR DESCRIPTION
Problem:
When options() is initialized after the OnMounted event, there are some errors as displayedOptions is not yet initialized as well:
`this.value(this.displayedOptions()[0].value);`

Solution:
Subscribe to options(), so whenever this value changes we properly initialize the rest.