### PR TITLE
Fixed: hyperlink popup gets truncated

### DIFF
--- a/src/ko/bindingHandlers/bindingHandlers.balloon.ts
+++ b/src/ko/bindingHandlers/bindingHandlers.balloon.ts
@@ -127,18 +127,20 @@ export class BalloonBindingHandler {
                             positionY = "bottom";
                             availableSpaceY = spaceBottom - egdeGap - padding;
                         }
+                        
+                        availableSpaceX = spaceLeft - egdeGap - padding;
                     }
                     else {
                         if (spaceLeft > spaceRight) {
                             positionX = "left";
                             availableSpaceX = spaceLeft - egdeGap;
-                            availableSpaceY = window.innerHeight - egdeGap - padding;
                         }
                         else {
                             positionX = "right";
                             availableSpaceX = spaceRight - egdeGap;
-                            availableSpaceY = window.innerHeight - egdeGap - padding;
                         }
+
+                        availableSpaceY = window.innerHeight - egdeGap - padding;
                     }
 
                     if (balloonRect.height > availableSpaceY) {


### PR DESCRIPTION
## Problem:
When a page is set to 320*256 pixels, "Web URL" control is getting truncated under hyperlink popup:
![_without](https://user-images.githubusercontent.com/92857141/221587270-c41c9cfc-ac81-4996-9f7c-8bdb974ebf28.png)

## Solution:
Calculate the available with space, even when the balloon is opened with preferredDirection set to "Vertical".
![_withwidth](https://user-images.githubusercontent.com/92857141/221587334-d7e4d5cd-d173-4222-933e-d065d1422703.gif)
