### PR TITLE
Continue process blocks if content of item is not presented

### DIFF
--- a/src/workshops/block/ko/blockSelector.ts
+++ b/src/workshops/block/ko/blockSelector.ts
@@ -98,6 +98,10 @@ export class BlockSelector {
 
             for (const block of blocks) {
                 const content = await this.blockService.getBlockContent(block.key);
+                
+                if(!content){
+                    continue;
+                }
 
                 if (!content.type) {
                     content.type = block.type;


### PR DESCRIPTION
In case of deleted sub item, the processing failed trying to access the property of null, which stops the process for all other blocks and breaks user experience. 
Solution is to continue the process avoiding such items to the resulted list.   