### PR TITLE
Fixed: unclickable links in vertical menu

### DIFF
--- a/src/menu/ko/verticalMenu.html
+++ b/src/menu/ko/verticalMenu.html
@@ -1,7 +1,7 @@
 <ul class="nav" data-bind="foreach: { data: $data.nodes, as: 'item' }">
     <!-- ko if: item.nodes().length > 0 -->
     <li class="nav-item" data-bind="css: { 'expanded': expanded }">
-        <a href="#" class="nav-link" data-toggle="dropdown"
+        <a href="#" class="nav-link"
             data-bind="text: item.label, hyperlink: item.hyperlink, css: { 'nav-link-active': item.isActive }"></a>
         <!--ko if: item.nodes().length > 0 -->
         <!-- ko template: { name: 'verticalMenu', data: item } -->


### PR DESCRIPTION
### Problem
The dropdown taggable feature is causing interference with the default click behavior of the links in the vertical menu.

### Solution
To resolve this issue, we can remove the data-toggle="dropdown" attribute since the menu does not have any dropdown functionality.