### PR TITLE
Fixed: editing a picture widget throws error

### DIFF
--- a/src/picture/pictureModel.ts
+++ b/src/picture/pictureModel.ts
@@ -34,4 +34,8 @@ export class PictureModel {
      * Picture styles.
      */
     public styles: LocalStyles;
+
+    constructor() {
+        this.styles = {};
+    }
 }


### PR DESCRIPTION
### Problem
When opening the picture editor, on initialize when trying to call `StyleHelper.getPluginConfigForLocalStyles(this.model.styles, "margin");`, model.styles is undefined, resulting in the following error: Parameter "localStyles" not specified.

### Solution
Add default value for `styles` in `PictureModel`